### PR TITLE
Add support for file window events on Wayland

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,6 +97,7 @@ rwh_06 = { package = "raw-window-handle", version = "0.6", features = [
 serde = { workspace = true, optional = true }
 smol_str = "0.2.0"
 tracing = { version = "0.1.40", default-features = false }
+url = "2.5.4"
 
 [dev-dependencies]
 image = { version = "0.25.0", default-features = false, features = ["png"] }

--- a/src/changelog/unreleased.md
+++ b/src/changelog/unreleased.md
@@ -16,6 +16,7 @@ on how to add them:
 - On X11, add `Window::even_more_rare_api`.
 - On Wayland, add `Window::common_api`.
 - On Windows, add `Window::some_rare_api`.
+- On Wayland, add support for `DroppedFile`, `HoveredFile` and `HoveredFileCancelled` window events.
 ```
 
 When the change requires non-trivial amount of work for users to comply

--- a/src/platform_impl/linux/wayland/seat/data_device/mod.rs
+++ b/src/platform_impl/linux/wayland/seat/data_device/mod.rs
@@ -1,21 +1,17 @@
-use sctk::data_device_manager::{
-    data_device::DataDeviceHandler,
-    data_offer::{DataOfferHandler, DragOffer},
-    data_source::DataSourceHandler,
-    WritePipe,
-};
-use wayland_client::{
-    protocol::{
-        wl_data_device::WlDataDevice, wl_data_device_manager::DndAction,
-        wl_data_source::WlDataSource, wl_surface::WlSurface,
-    },
-    Connection, Proxy, QueueHandle,
-};
+use sctk::data_device_manager::data_device::DataDeviceHandler;
+use sctk::data_device_manager::data_offer::{DataOfferHandler, DragOffer};
+use sctk::data_device_manager::data_source::DataSourceHandler;
+use sctk::data_device_manager::WritePipe;
+use wayland_client::protocol::wl_data_device::WlDataDevice;
+use wayland_client::protocol::wl_data_device_manager::DndAction;
+use wayland_client::protocol::wl_data_source::WlDataSource;
+use wayland_client::protocol::wl_surface::WlSurface;
+use wayland_client::{Connection, Proxy, QueueHandle};
 
-use crate::{
-    event::WindowEvent,
-    platform_impl::wayland::{self, state::WinitState, types::dnd::DndOfferState},
-};
+use crate::event::WindowEvent;
+use crate::platform_impl::wayland::state::WinitState;
+use crate::platform_impl::wayland::types::dnd::DndOfferState;
+use crate::platform_impl::wayland::{self};
 
 const SUPPORTED_MIME_TYPES: &[&str] = &["text/uri-list"];
 
@@ -53,13 +49,10 @@ impl DataDeviceHandler for WinitState {
                         let window_id = wayland::make_wid(&offer.surface);
 
                         self.read_file_paths(read_pipe, move |state, path| {
-                            state.dnd_offers.insert(
-                                surface_id.clone(),
-                                DndOfferState {
-                                    offer: current_offer.clone(),
-                                    file_path: path.clone(),
-                                },
-                            );
+                            state.dnd_offers.insert(surface_id.clone(), DndOfferState {
+                                offer: current_offer.clone(),
+                                file_path: path.clone(),
+                            });
 
                             state
                                 .events_sink

--- a/src/platform_impl/linux/wayland/seat/data_device/mod.rs
+++ b/src/platform_impl/linux/wayland/seat/data_device/mod.rs
@@ -1,0 +1,199 @@
+use sctk::data_device_manager::{
+    data_device::DataDeviceHandler,
+    data_offer::{DataOfferHandler, DragOffer},
+    data_source::DataSourceHandler,
+    WritePipe,
+};
+use wayland_client::{
+    protocol::{
+        wl_data_device::WlDataDevice, wl_data_device_manager::DndAction,
+        wl_data_source::WlDataSource, wl_surface::WlSurface,
+    },
+    Connection, Proxy, QueueHandle,
+};
+
+use crate::{
+    event::WindowEvent,
+    platform_impl::wayland::{self, state::WinitState, types::dnd::DndOfferState},
+};
+
+const SUPPORTED_MIME_TYPES: &[&str] = &["text/uri-list"];
+
+fn filter_mime(mime_types: &[String]) -> Option<String> {
+    for mime in mime_types {
+        if SUPPORTED_MIME_TYPES.contains(&mime.as_str()) {
+            return Some(mime.clone());
+        }
+    }
+
+    None
+}
+
+impl DataDeviceHandler for WinitState {
+    fn enter(
+        &mut self,
+        _: &Connection,
+        _: &QueueHandle<Self>,
+        wl_data_device: &WlDataDevice,
+        _: f64,
+        _: f64,
+        _: &WlSurface,
+    ) {
+        let data_device = self.get_data_device(wl_data_device);
+
+        if let Some(data_device) = data_device {
+            if let Some(offer) = data_device.data().drag_offer() {
+                if let Some(mime_type) = offer.with_mime_types(filter_mime) {
+                    offer.accept_mime_type(offer.serial, Some(mime_type.clone()));
+                    offer.set_actions(DndAction::Copy, DndAction::Copy);
+
+                    if let Ok(read_pipe) = offer.receive(mime_type) {
+                        let surface_id = offer.surface.id();
+                        let current_offer = offer.clone();
+                        let window_id = wayland::make_wid(&offer.surface);
+
+                        self.read_file_paths(read_pipe, move |state, path| {
+                            state.dnd_offers.insert(
+                                surface_id.clone(),
+                                DndOfferState {
+                                    offer: current_offer.clone(),
+                                    file_path: path.clone(),
+                                },
+                            );
+
+                            state
+                                .events_sink
+                                .push_window_event(WindowEvent::HoveredFile(path), window_id);
+                        });
+                    }
+                }
+            }
+        }
+    }
+
+    fn leave(&mut self, _: &Connection, _: &QueueHandle<Self>, wl_data_device: &WlDataDevice) {
+        let data_device = self.get_data_device(wl_data_device);
+
+        if let Some(data_device) = data_device {
+            if let Some(offer) = data_device.data().drag_offer() {
+                if let Some(dnd) = self.dnd_offers.remove(&offer.surface.id()) {
+                    let window_id = wayland::make_wid(&offer.surface);
+                    self.events_sink
+                        .push_window_event(WindowEvent::HoveredFileCancelled, window_id);
+
+                    dnd.offer.destroy();
+                } else {
+                    offer.destroy();
+                }
+            }
+        }
+    }
+
+    fn motion(
+        &mut self,
+        _: &Connection,
+        _: &QueueHandle<Self>,
+        wl_data_device: &WlDataDevice,
+        _: f64,
+        _: f64,
+    ) {
+        let data_device = self.get_data_device(wl_data_device);
+
+        if let Some(data_device) = data_device {
+            if let Some(offer) = data_device.data().drag_offer() {
+                let surface_id = offer.surface.id();
+                let window_id = wayland::make_wid(&offer.surface);
+
+                if let Some(dnd) = self.dnd_offers.get(&surface_id) {
+                    self.events_sink.push_window_event(
+                        WindowEvent::HoveredFile(dnd.file_path.clone()),
+                        window_id,
+                    );
+                }
+            }
+        }
+    }
+
+    fn selection(&mut self, _: &Connection, _: &QueueHandle<Self>, _: &WlDataDevice) {}
+
+    fn drop_performed(
+        &mut self,
+        _: &Connection,
+        _: &QueueHandle<Self>,
+        wl_data_device: &WlDataDevice,
+    ) {
+        let data_device = self.get_data_device(wl_data_device);
+
+        if let Some(data_device) = data_device {
+            if let Some(offer) = data_device.data().drag_offer() {
+                let surface_id = offer.surface.id();
+                let window_id = wayland::make_wid(&offer.surface);
+
+                if let Some(dnd) = self.dnd_offers.remove(&surface_id) {
+                    self.events_sink.push_window_event(
+                        WindowEvent::DroppedFile(dnd.file_path.clone()),
+                        window_id,
+                    );
+
+                    dnd.offer.finish();
+                    dnd.offer.destroy();
+                } else {
+                    offer.finish();
+                    offer.destroy();
+                }
+            }
+        }
+    }
+}
+
+impl DataSourceHandler for WinitState {
+    fn accept_mime(
+        &mut self,
+        _: &Connection,
+        _: &QueueHandle<Self>,
+        _: &WlDataSource,
+        _: Option<String>,
+    ) {
+    }
+
+    fn send_request(
+        &mut self,
+        _: &Connection,
+        _: &QueueHandle<Self>,
+        _: &WlDataSource,
+        _: String,
+        _: WritePipe,
+    ) {
+    }
+
+    fn cancelled(&mut self, _: &Connection, _: &QueueHandle<Self>, _: &WlDataSource) {}
+
+    fn dnd_dropped(&mut self, _: &Connection, _: &QueueHandle<Self>, _: &WlDataSource) {}
+
+    fn dnd_finished(&mut self, _: &Connection, _: &QueueHandle<Self>, _: &WlDataSource) {}
+
+    fn action(&mut self, _: &Connection, _: &QueueHandle<Self>, _: &WlDataSource, _: DndAction) {}
+}
+
+impl DataOfferHandler for WinitState {
+    fn source_actions(
+        &mut self,
+        _: &Connection,
+        _: &QueueHandle<Self>,
+        offer: &mut DragOffer,
+        _: DndAction,
+    ) {
+        offer.set_actions(DndAction::Copy, DndAction::Copy);
+    }
+
+    fn selected_action(
+        &mut self,
+        _: &Connection,
+        _: &QueueHandle<Self>,
+        _: &mut DragOffer,
+        _: DndAction,
+    ) {
+    }
+}
+
+sctk::delegate_data_device!(WinitState);

--- a/src/platform_impl/linux/wayland/seat/mod.rs
+++ b/src/platform_impl/linux/wayland/seat/mod.rs
@@ -67,6 +67,7 @@ pub struct WinitSeatState {
     /// Whether we have pending modifiers.
     modifiers_pending: bool,
 
+    /// The current data device.
     data_device: Option<DataDevice>,
 }
 

--- a/src/platform_impl/linux/wayland/seat/mod.rs
+++ b/src/platform_impl/linux/wayland/seat/mod.rs
@@ -1,8 +1,14 @@
 //! Seat handling.
 
+use std::fs::File;
+use std::io::Read;
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use ahash::AHashMap;
+use calloop::PostAction;
+use sctk::data_device_manager::data_device::DataDevice;
+use sctk::data_device_manager::ReadPipe;
 use tracing::warn;
 
 use sctk::reexports::client::backend::ObjectId;
@@ -14,11 +20,14 @@ use sctk::reexports::protocols::wp::text_input::zv3::client::zwp_text_input_v3::
 
 use sctk::seat::pointer::{ThemeSpec, ThemedPointer};
 use sctk::seat::{Capability as SeatCapability, SeatHandler, SeatState};
+use url::Url;
+use wayland_client::protocol::wl_data_device::WlDataDevice;
 
 use crate::event::WindowEvent;
 use crate::keyboard::ModifiersState;
 use crate::platform_impl::wayland::state::WinitState;
 
+mod data_device;
 mod keyboard;
 mod pointer;
 mod text_input;
@@ -57,6 +66,8 @@ pub struct WinitSeatState {
 
     /// Whether we have pending modifiers.
     modifiers_pending: bool,
+
+    data_device: Option<DataDevice>,
 }
 
 impl WinitSeatState {
@@ -140,6 +151,11 @@ impl SeatHandler for WinitState {
                 queue_handle,
                 TextInputData::default(),
             )));
+        }
+
+        if seat_state.data_device.is_none() {
+            let data_device = self.data_device_manager_state.get_data_device(queue_handle, &seat);
+            seat_state.data_device = Some(data_device);
         }
     }
 
@@ -229,6 +245,40 @@ impl WinitState {
                 self.events_sink.push_window_event(WindowEvent::Focused(false), *window_id);
             }
         }
+    }
+
+    fn get_data_device(&self, wl_data_device: &WlDataDevice) -> Option<&DataDevice> {
+        self.seats.values().find_map(|seat| {
+            let data_device = seat.data_device.as_ref()?;
+            (data_device.inner() == wl_data_device).then_some(data_device)
+        })
+    }
+
+    fn read_file_paths<F: Fn(&mut Self, PathBuf) + 'static>(
+        &self,
+        read_pipe: ReadPipe,
+        callback: F,
+    ) {
+        self.loop_handle
+            .insert_source(read_pipe, move |_, file, state| {
+                let mut data = String::new();
+
+                let file: &mut File = unsafe { file.get_mut() };
+                if file.read_to_string(&mut data).is_ok() {
+                    if let Some(line) = data.lines().next() {
+                        if let Ok(url) = Url::parse(line) {
+                            if url.scheme() == "file" {
+                                if let Ok(path) = url.to_file_path() {
+                                    callback(state, path)
+                                }
+                            }
+                        }
+                    }
+                }
+
+                PostAction::Remove
+            })
+            .ok();
     }
 }
 

--- a/src/platform_impl/linux/wayland/state.rs
+++ b/src/platform_impl/linux/wayland/state.rs
@@ -56,7 +56,10 @@ pub struct WinitState {
     /// The seat state responsible for all sorts of input.
     pub seat_state: SeatState,
 
+    // The state of the data device manager.
     pub data_device_manager_state: DataDeviceManagerState,
+
+    // The active drag and drop offers.
     pub dnd_offers: AHashMap<ObjectId, DndOfferState>,
 
     /// The shm for software buffers, such as cursors.

--- a/src/platform_impl/linux/wayland/state.rs
+++ b/src/platform_impl/linux/wayland/state.rs
@@ -57,7 +57,7 @@ pub struct WinitState {
     pub seat_state: SeatState,
 
     pub data_device_manager_state: DataDeviceManagerState,
-    pub dnd_offers: AHashMap<ObjectId, DndOfferState>,
+    pub dnd_offer: Option<DndOfferState>,
 
     /// The shm for software buffers, such as cursors.
     pub shm: Shm,
@@ -148,7 +148,6 @@ impl WinitState {
 
         let data_device_manager_state =
             DataDeviceManagerState::bind(globals, queue_handle).map_err(WaylandError::Bind)?;
-        let dnd_offers = AHashMap::default();
 
         let seat_state = SeatState::new(globals, queue_handle);
 
@@ -175,7 +174,7 @@ impl WinitState {
             seat_state,
 
             data_device_manager_state,
-            dnd_offers,
+            dnd_offer: None,
 
             shm,
             custom_cursor_pool,

--- a/src/platform_impl/linux/wayland/state.rs
+++ b/src/platform_impl/linux/wayland/state.rs
@@ -57,7 +57,7 @@ pub struct WinitState {
     pub seat_state: SeatState,
 
     pub data_device_manager_state: DataDeviceManagerState,
-    pub dnd_offer: Option<DndOfferState>,
+    pub dnd_offers: AHashMap<ObjectId, DndOfferState>,
 
     /// The shm for software buffers, such as cursors.
     pub shm: Shm,
@@ -174,7 +174,7 @@ impl WinitState {
             seat_state,
 
             data_device_manager_state,
-            dnd_offer: None,
+            dnd_offers: AHashMap::default(),
 
             shm,
             custom_cursor_pool,

--- a/src/platform_impl/linux/wayland/types/dnd.rs
+++ b/src/platform_impl/linux/wayland/types/dnd.rs
@@ -1,8 +1,8 @@
 use std::path::PathBuf;
 
-use sctk::data_device_manager::data_offer::DragOffer;
+use wayland_client::protocol::wl_surface::WlSurface;
 
 pub struct DndOfferState {
-    pub offer: DragOffer,
-    pub file_path: PathBuf,
+    pub surface: WlSurface,
+    pub path: PathBuf,
 }

--- a/src/platform_impl/linux/wayland/types/dnd.rs
+++ b/src/platform_impl/linux/wayland/types/dnd.rs
@@ -1,0 +1,8 @@
+use std::path::PathBuf;
+
+use sctk::data_device_manager::data_offer::DragOffer;
+
+pub struct DndOfferState {
+    pub offer: DragOffer,
+    pub file_path: PathBuf,
+}

--- a/src/platform_impl/linux/wayland/types/mod.rs
+++ b/src/platform_impl/linux/wayland/types/mod.rs
@@ -1,6 +1,7 @@
 //! Wayland protocol implementation boilerplate.
 
 pub mod cursor;
+pub mod dnd;
 pub mod kwin_blur;
 pub mod wp_fractional_scaling;
 pub mod wp_viewporter;


### PR DESCRIPTION
Add support for DroppedFile, HoveredFileCancelled and HoveredFile window events that were not supported on Wayland.

- [x] Tested on all platforms changed
- [x] Added an entry to the `changelog` module if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
